### PR TITLE
Package/bower

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -5,7 +5,7 @@
     "Preston Van Loon <preston@machinepowered.com>"
   ],
   "description": "New Relic Browser Insights for Angular.js",
-  "main": "./dist/newrelic-angular.min.js",
+  "main": "./dist/newrelic-angular.js",
   "keywords": [
     "New Relic"
   ],

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "newrelic-angular",
   "version": "0.1.2",
   "description": "New Relic Browser Insights for Angular.js",
-  "main": "dist/newrelic-angular.min.js",
+  "main": "dist/newrelic-angular.js",
   "dependencies": {
     "angulartics": "^0.19.2"
   },


### PR DESCRIPTION
Tiny detail, but I think we may want to opt into using the non minified versions in the main directory. This would make debugging easier and will allow the implementor to make minification part of their build process. 

[bower.json specification](https://github.com/bower/spec/blob/master/json.md) also states not to include minified versions in the build process:
- Use source files with module exports and imports over pre-built distribution files.
- Do not include minified files.
- Do not include assets files like images, fonts, audio, or video
- Filenames should not be versioned (Bad: package.1.1.0.js; Good: package.js).
- Globs like js/*.js are not allowed.
