### PR TITLE
Fix require('newrelic-angular')

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "newrelic-angular",
   "description": "New Relic Browser Insights for Angular.js",
-  "main": "lib/module.js",
+  "main": "dist/newrelic-angular.js",
   "version": "0.2.1",
   "dependencies": {
     "angulartics": "^1.0.3",


### PR DESCRIPTION
main was pointing to a path that did not exist, so require was unable to resolve the dependency.

closes #68 