### PR TITLE
Fix: Nullable config reference

### DIFF
--- a/src/interceptors/http.js
+++ b/src/interceptors/http.js
@@ -45,7 +45,7 @@
           var config = rejection.config || {};
 
           if ( ! shouldIgnoreStatus(rejection.status) ) {
-            var err = 'bad ' + config.method + ' ' + httpType + ' ' + rejection.config.url;
+            var err = 'bad ' + config.method + ' ' + httpType + ' ' + config.url;
             $log.error(new Error(err));
           }
           return $q.reject(rejection);


### PR DESCRIPTION
This branch fixes a reference to a potentially undefined config reference.

A local config var is set in case of an undefined value and should be
used instead of the original value.